### PR TITLE
Image Deletion Bugfix

### DIFF
--- a/app/assets/javascripts/dante/editor.js.coffee
+++ b/app/assets/javascripts/dante/editor.js.coffee
@@ -762,10 +762,10 @@ class Dante.Editor extends Dante.View
 
       #select an image if backspacing into it from a paragraph
       if($(anchor_node).hasClass("graf--p") && @isFirstChar)
-          if($(anchor_node).prev().hasClass("graf--figure"))
-            e.preventDefault();
-            $(anchor_node).prev().find("img").click();
-            utils.log("Focus on the previous image")
+        if($(anchor_node).prev().hasClass("graf--figure") && @getSelectedText().length == 0)
+          e.preventDefault();
+          $(anchor_node).prev().find("img").click();
+          utils.log("Focus on the previous image");
 
       if $(utils_anchor_node).hasClass("section-content") || $(utils_anchor_node).hasClass("graf--first")
         utils.log "SECTION DETECTED FROM KEYDOWN #{_.isEmpty($(utils_anchor_node).text())}"
@@ -1226,7 +1226,7 @@ class Dante.Editor extends Dante.View
       content = $li.html()
       @replaceWith("p", $li)
       $paragraph = $(".is-selected")
-      $paragraph.removeClass("graf--empty").html(content)
+      $paragraph.removeClass("graf--empty").html(content).attr("name", utils.generateUniqueName());
 
       if($list.children().length is 0)
         $list.remove()


### PR DESCRIPTION
Fixed a bug where selecting a block of text starting at the beginning of a paragraph and then pressing backspace would select an image above that paragraph instead of deleting the selection. It now deletes the selection instead of selecting the image.

Also fixed a minor bug where backspacing out of lists would generate paragraphs without unique names.
